### PR TITLE
Blog generation feed rss

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use pages::{
 };
 use ssg::Ssg;
 use tokio::sync::RwLock;
-use utils::generate_this_week_feed_rss;
+use utils::generate_feed_rss;
 use utils::{fetch_dev_to::fetch_dev_to, fetch_hashnode::fetch_hashnode};
 
 use crate::pages::{article_page::ArticlePage, home::Homepage};
@@ -69,7 +69,13 @@ async fn generate_esta_semana_en_rust<'a>(
         .filter(|article| article.number_of_week.is_some())
         .collect::<Vec<Article>>();
 
-    generate_this_week_feed_rss(&articles);
+    generate_feed_rss(
+        &articles,
+        "./out/this_week_feed.xml",
+        "Esta Semana en Rust",
+        "Revisa que esta pasando en la comunidad de Rust Lang en Español",
+        "tags/esta-semana-en-rust.html",
+    );
 
     for article in articles.clone() {
         ssg.gen(&format!("articles/{}.html", article.slug), || {
@@ -86,6 +92,22 @@ async fn generate_post_pages<'a>(
     ssg: &Ssg<'a>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     tokio::fs::create_dir_all("./out/articles").await?;
+
+    {
+        let articles = articles
+            .clone()
+            .into_iter()
+            .filter(|a| a.number_of_week.is_none())
+            .collect::<Vec<Article>>();
+
+        generate_feed_rss(
+            &articles,
+            "./out/feed.xml",
+            "Blog de RustLangES",
+            "Enterate del mejor contenido en Español sobre Rust",
+            "",
+        );
+    }
 
     for article in articles.clone() {
         if article.number_of_week.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ async fn generate_esta_semana_en_rust<'a>(
         "./out/this_week_feed.xml",
         "Esta Semana en Rust",
         "Revisa que esta pasando en la comunidad de Rust Lang en Español",
-        "tags/esta-semana-en-rust.html",
+        Some("tags/esta-semana-en-rust.html"),
     );
 
     for article in articles.clone() {
@@ -105,7 +105,7 @@ async fn generate_post_pages<'a>(
             "./out/feed.xml",
             "Blog de RustLangES",
             "Enterate del mejor contenido en Español sobre Rust",
-            "",
+            None,
         );
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,13 @@ use crate::models::article::Article;
 pub mod fetch_dev_to;
 pub mod fetch_hashnode;
 
-pub fn generate_this_week_feed_rss(articles: &[Article]) {
+pub fn generate_feed_rss(
+    articles: &[Article],
+    out_file: &str,
+    title: &str,
+    description: &str,
+    link_path: &str,
+) {
     let categories = articles
         .iter()
         .flat_map(|a| a.tags.clone().unwrap_or_default())
@@ -38,9 +44,9 @@ pub fn generate_this_week_feed_rss(articles: &[Article]) {
 
     let channel = ChannelBuilder::default()
         .language(Some("es".to_string()))
-        .title("Esta Semana en Rust".to_string())
-        .description("Revisa que esta pasando en la comunidad de Rust Lang en Español".to_string())
-        .link("https://rustlanges.github.io/blog/tags/esta-semana-en-rust.html".to_string())
+        .title(title.to_string())
+        .description(description.to_string())
+        .link(format!("https://rustlanges.github.io/blog/{link_path}"))
         .categories(categories)
         .items(items)
         .build();
@@ -49,6 +55,6 @@ pub fn generate_this_week_feed_rss(articles: &[Article]) {
 
     let channel_str = channel.to_string();
 
-    fs::write("./out/this_week_feed.xml", channel_str).unwrap();
-    println!("wrote ./out/this_week_feed.xml");
+    fs::write(out_file, channel_str).unwrap();
+    println!("wrote {out_file}");
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,7 @@ pub fn generate_feed_rss(
     out_file: &str,
     title: &str,
     description: &str,
-    link_path: &str,
+    link_path: Option<&str>,
 ) {
     let categories = articles
         .iter()
@@ -46,7 +46,10 @@ pub fn generate_feed_rss(
         .language(Some("es".to_string()))
         .title(title.to_string())
         .description(description.to_string())
-        .link(format!("https://rustlanges.github.io/blog/{link_path}"))
+        .link(format!(
+            "https://rustlanges.github.io/blog/{}",
+            link_path.unwrap_or_default()
+        ))
         .categories(categories)
         .items(items)
         .build();


### PR DESCRIPTION
Arreglos:
- Se modifico la función de generación de rss para que sea mas flexible (Esto para permitir la generación de cualquier cosa que sea un articulo)
- Se modifico el uso de la función para la generación del rss para los artículos de `Esta Semana en Rust`

Novedades:
- Se implemento la nueva función para generar un archivo `feed.xml` para los artículos del blog