### PR TITLE
Feat(add): for create dir in rust

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ pub static ARTICLES: Lazy<RwLock<Vec<Article>>> =
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let articles = list_articles().await?;
     ARTICLES.write().await.extend(articles.clone()); // Set the articles in the ARTICLES static variable
+    std::fs::create_dir("out").expect("Cannot create 'out' directory");
     let ssg = Ssg::new(Path::new("./out"));
 
     // generate the pages


### PR DESCRIPTION
agregado std::fs::create_dir("out").except("Cannot create 'out' directory") en main.rs para crear la carpeta