### PR TITLE
Use absolute paths in pagination buttons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,19 +2,25 @@
     "emmet.includeLanguages": {
         "rust": "html",
         "*.rs": "html"
-      },
-      "tailwindCSS.includeLanguages": {
-          "rust": "html",
-          "*.rs": "html"
-      },
-      "files.associations": {
-          "*.rs": "rust"
-      },
-      "editor.quickSuggestions": {
+    },
+    "tailwindCSS.includeLanguages": {
+        "rust": "html",
+        "*.rs": "html"
+    },
+    "files.associations": {
+        "*.rs": "rust"
+    },
+    "editor.quickSuggestions": {
         "other": "on",
         "comments": "on",
         "strings": true
-      },
-      "css.validate": false,
-      "rust-analyzer.rustfmt.overrideCommand": ["leptosfmt", "--stdin", "--rustfmt"]
+    },
+    "css.validate": false,
+    "rust-analyzer.rustfmt.overrideCommand": [
+        "leptosfmt",
+        "--stdin",
+        "--rustfmt"
+    ],
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.checkOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,5 @@
         "strings": true
       },
       "css.validate": false,
+      "rust-analyzer.rustfmt.overrideCommand": ["leptosfmt", "--stdin", "--rustfmt"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,9 @@
         "--rustfmt"
     ],
     "rust-analyzer.check.command": "clippy",
-    "rust-analyzer.checkOnSave": true
+    "rust-analyzer.checkOnSave": true,
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/target": true
+    }
 }

--- a/src/components/feature_articles.rs
+++ b/src/components/feature_articles.rs
@@ -16,7 +16,7 @@ use leptos_mdx::mdx::Mdx;
 
 pub async fn featured_articles() -> impl IntoView {
     let articles = ARTICLES.read().await.clone();
-    let _invalid_tags = vec![
+    let _invalid_tags = [
         "esta semana en rust".to_string(),
         "anuncio de la comunidad".to_string(),
     ];

--- a/src/components/icons/mod.rs
+++ b/src/components/icons/mod.rs
@@ -22,7 +22,7 @@ pub fn StrToIcon(
     #[prop(default = 40)] size: u32,
     #[prop(default = "")] class: &'static str,
 ) -> impl IntoView {
-    let class = "fill-black dark:fill-white ".to_owned() + &class;
+    let class = "fill-black dark:fill-white ".to_owned() + class;
 
     match v.as_str() {
         "github" => view! {

--- a/src/components/pagination_buttons.rs
+++ b/src/components/pagination_buttons.rs
@@ -18,7 +18,7 @@ pub fn PaginationButtons(
                 view! {
                     <>
                         <PreviousPageButton page=current_page/>
-                        <NextPageButton page=current_page max_page hide=hide_next_page_button/>
+                        <NextPageButton page=current_page hide=hide_next_page_button/>
                     </>
                 }
             }}
@@ -35,9 +35,9 @@ pub fn PreviousPageButton(page: Option<usize>) -> impl IntoView {
     }
 
     let previous_page = if page == 1 {
-        "..".to_string()
+        "/".to_string()
     } else {
-        format!("../pages/{}.html", page - 1)
+        format!("/pages/{}.html", page - 1)
     };
 
     view! {
@@ -54,18 +54,13 @@ pub fn PreviousPageButton(page: Option<usize>) -> impl IntoView {
 }
 
 #[component]
-pub fn NextPageButton(page: Option<usize>, max_page: usize, hide: bool) -> impl IntoView {
+pub fn NextPageButton(page: Option<usize>, hide: bool) -> impl IntoView {
     if hide {
         return view! { <></> };
     }
 
     let page = page.unwrap_or(0);
-
-    let link = if max_page == 0 {
-        format!("./pages/{}.html", page + 1)
-    } else {
-        format!("../pages/{}.html", page + 1)
-    };
+    let link = format!("/pages/{}.html", page + 1);
 
     view! {
         <>

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ARTICLES.write().await.extend(articles.clone()); // Set the articles in the ARTICLES static variable
     let out = Path::new("./out");
     if !out.exists() {
-        std::fs::create_dir(&out).expect("Cannot create 'out' directory");
+        std::fs::create_dir(out).expect("Cannot create 'out' directory");
     }
     let ssg = Ssg::new(out);
 


### PR DESCRIPTION
## Changes

- Simplify logic in `PaginationButtons` using absolute paths
- Add `leptosfmt` as format command and `clippy` as lint command in vscode
- Ignore `target` dir in vscode search (<kbd>ctrl+p</kbd>)
- Simplify logic in `PaginationButtons` using the `Show` leptos component