### PR TITLE
fix: remove _blank to "aprende" route

### DIFF
--- a/src/components/esta_semana_en_rust/header.rs
+++ b/src/components/esta_semana_en_rust/header.rs
@@ -41,9 +41,7 @@ pub fn Header() -> impl IntoView {
                             </a>
                         </li>
                         <li>
-                            <a href="/aprende" target="_blank">
-                                "Aprende"
-                            </a>
+                            <a href="/aprende">"Aprende"</a>
                         </li>
                         <li>
                             <a href="/comunidad">"Comunidad"</a>

--- a/src/components/header.rs
+++ b/src/components/header.rs
@@ -35,9 +35,7 @@ pub fn Header() -> impl IntoView {
                             </a>
                         </li>
                         <li>
-                            <a href="/aprende" target="_blank">
-                                "Aprende"
-                            </a>
+                            <a href="/aprende">"Aprende"</a>
                         </li>
                         <li>
                             <a href="/comunidad">"Comunidad"</a>


### PR DESCRIPTION
I forgot to remove the _blank target from a link that navigates within the same website.