### PR TITLE
Fix sed in workflow, escape links

### DIFF
--- a/.github/workflows/this_week_in_rust.yml
+++ b/.github/workflows/this_week_in_rust.yml
@@ -72,7 +72,7 @@ jobs:
           sed -i -e 's/] (http/](http/g' "$DATE-this-week-in-rust.md"
           sed -i -e 's/Óxido/Rust/g' "$DATE-this-week-in-rust.md"
           sed -i -e 's/óxido/Rust/g' "$DATE-this-week-in-rust.md"
-          sed -i -e 's/[Equipo de la comunidad de Rust] [comunidad]/[Equipo de la comunidad de Rust][comunidad]/g' "$DATE-this-week-in-rust.md"
+          sed -i -e 's/\[Equipo de la comunidad de Rust\] \[comunidad\]/[Equipo de la comunidad de Rust][comunidad]/g' "$DATE-this-week-in-rust.md"
           sed -i -e 's/envíanos una solicitud de extracción/envíanos un PR/g' "$DATE-this-week-in-rust.md"
           sed -i -e 's/## Caja de la semana/## Crate de la semana/g' "$DATE-this-week-in-rust.md"
           sed -i -e 's/La caja de esta semana/El crate de esta semana/g' "$DATE-this-week-in-rust.md"


### PR DESCRIPTION
@krovuxdev Como arreglaste los articulos en si? Manualmente?
Este bug ha afectado a todos los articulos desde 01-01-2025, bugfix a 24e44c299cb8ce5a83c42c0c9e540836ffe25a4f